### PR TITLE
docs: correct get started heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ LightM-UNet is a lightweight fusion of UNet and Mamba, boasting a mere parameter
 
 ![result](https://github.com/MrBlankness/LightM-UNet/blob/master/assets/main_result.png)
 
-## Get Start 
+## Get Started 
 
 Requirements: `CUDA ≥ 11.6`
 


### PR DESCRIPTION
## Summary
- fix typo in README section heading from "Get Start" to "Get Started"

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'batchgenerators')*


------
https://chatgpt.com/codex/tasks/task_e_68af5aa18bac8321b4af953bce3a9025