### PR TITLE
Fix MambaLayer dtype restoration

### DIFF
--- a/lightm-unet/nnunetv2/nets/UMambaEnc.py
+++ b/lightm-unet/nnunetv2/nets/UMambaEnc.py
@@ -35,7 +35,8 @@ class MambaLayer(nn.Module):
     
     @autocast(enabled=False)
     def forward(self, x):
-        if x.dtype == torch.float16:
+        input_dtype = x.dtype
+        if input_dtype == torch.float16:
             x = x.type(torch.float32)
         B, C = x.shape[:2]
         assert C == self.dim
@@ -46,7 +47,7 @@ class MambaLayer(nn.Module):
         x_mamba = self.mamba(x_norm)
         out = x_mamba.transpose(-1, -2).reshape(B, C, *img_dims)
 
-        return out
+        return out.type(input_dtype)
 
 
 class ResidualMambaEncoder(nn.Module):

--- a/lightm-unet/nnunetv2/tests/test_mambalayer_dtype.py
+++ b/lightm-unet/nnunetv2/tests/test_mambalayer_dtype.py
@@ -1,0 +1,30 @@
+import sys
+import types
+import pytest
+
+try:  # pragma: no cover - handled gracefully if torch is missing
+    import torch
+except Exception:  # pragma: no cover
+    pytest.skip("torch is required for this test", allow_module_level=True)
+
+# Create a dummy mamba_ssm module so that LightMUNet can be imported
+mamba_ssm = types.ModuleType("mamba_ssm")
+
+class DummyMamba(torch.nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def forward(self, x):
+        return x
+
+mamba_ssm.Mamba = DummyMamba
+sys.modules["mamba_ssm"] = mamba_ssm
+
+from nnunetv2.nets.LightMUNet import MambaLayer
+
+
+def test_mambalayer_preserves_input_dtype():
+    layer = MambaLayer(input_dim=4, output_dim=4)
+    x = torch.randn(2, 4, 3, 3, dtype=torch.float16)
+    out = layer(x)
+    assert out.dtype == x.dtype


### PR DESCRIPTION
## Summary
- ensure `MambaLayer` returns tensors in the same dtype as its input
- add regression test for `MambaLayer` dtype handling (skipped if dependencies missing)

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'batchgenerators')*
- `pytest lightm-unet/nnunetv2/tests/test_mambalayer_dtype.py` *(skipped: torch is required for this test)*

------
https://chatgpt.com/codex/tasks/task_e_68af576b54bc8321b705d5b97c61b07f