### PR TITLE
Clarify deep supervision weighting behavior

### DIFF
--- a/lightm-unet/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerCELoss.py
+++ b/lightm-unet/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerCELoss.py
@@ -19,7 +19,7 @@ class nnUNetTrainerCELoss(nnUNetTrainer):
             weights = np.array([1 / (2**i) for i in range(len(deep_supervision_scales))])
             weights[-1] = 0
 
-            # we don't use the lowest 2 outputs. Normalize weights so that they sum to 1
+            # we don't use the lowest output. Normalize weights so that they sum to 1
             weights = weights / weights.sum()
             # now wrap the loss
             loss = DeepSupervisionWrapper(loss, weights)


### PR DESCRIPTION
## Summary
- Fix comment in CELoss trainer to note that only the lowest-resolution output is ignored when weighting deep supervision outputs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'batchgenerators')*

------
https://chatgpt.com/codex/tasks/task_e_68af5aa61d788321bf54518128d89740