### PR TITLE
refactor: replace division with reciprocal multiplication

### DIFF
--- a/lightm-unet/nnunetv2/dataset_conversion/Dataset114_MNMs.py
+++ b/lightm-unet/nnunetv2/dataset_conversion/Dataset114_MNMs.py
@@ -4,6 +4,7 @@ import random
 from pathlib import Path
 
 import nibabel as nib
+import numpy as np
 from batchgenerators.utilities.file_and_folder_operations import load_json, save_json
 
 from nnunetv2.dataset_conversion.Dataset027_ACDC import make_out_dirs
@@ -114,8 +115,11 @@ def create_custom_splits(src_data_folder: Path, csv_file: str, dataset_id: int, 
     # Build filenames from corresponding patient frames
     train_a = [f"{patient}_frame{patient_info[patient][frame]:02d}" for patient in train_a for frame in ["es", "ed"]]
     train_b = [f"{patient}_frame{patient_info[patient][frame]:02d}" for patient in train_b for frame in ["es", "ed"]]
-    train_a_mix_1, train_a_mix_2 = train_a[: len(train_a) // 2], train_a[len(train_a) // 2 :]
-    train_b_mix_1, train_b_mix_2 = train_b[: len(train_b) // 2], train_b[len(train_b) // 2 :]
+    inv_two = np.reciprocal(2.0)
+    half_a = int(len(train_a) * inv_two)
+    train_a_mix_1, train_a_mix_2 = train_a[:half_a], train_a[half_a:]
+    half_b = int(len(train_b) * inv_two)
+    train_b_mix_1, train_b_mix_2 = train_b[:half_b], train_b[half_b:]
     val_a = [f"{patient}_frame{patient_info[patient][frame]:02d}" for patient in val_a for frame in ["es", "ed"]]
     val_b = [f"{patient}_frame{patient_info[patient][frame]:02d}" for patient in val_b for frame in ["es", "ed"]]
 

--- a/lightm-unet/nnunetv2/dataset_conversion/datasets_for_integration_tests/Dataset996_IntegrationTest_Hippocampus_regions_ignore.py
+++ b/lightm-unet/nnunetv2/dataset_conversion/datasets_for_integration_tests/Dataset996_IntegrationTest_Hippocampus_regions_ignore.py
@@ -9,6 +9,8 @@ from nnunetv2.paths import nnUNet_raw
 from nnunetv2.utilities.label_handling.label_handling import LabelManager
 from nnunetv2.utilities.plans_handling.plans_handler import PlansManager, ConfigurationManager
 
+ONE_THIRD = np.reciprocal(3.0)
+
 
 def sparsify_segmentation(seg: np.ndarray, label_manager: LabelManager, percent_of_slices: float) -> np.ndarray:
         assert label_manager.has_ignore_label, "This preprocessor only works with datasets that have an ignore label!"
@@ -68,7 +70,7 @@ if __name__ == '__main__':
     for s in segs:
         seg_itk = sitk.ReadImage(s)
         seg_npy = sitk.GetArrayFromImage(seg_itk)
-        seg_npy = sparsify_segmentation(seg_npy, lm, 0.1 / 3)
+        seg_npy = sparsify_segmentation(seg_npy, lm, 0.1 * ONE_THIRD)
         seg_itk_new = sitk.GetImageFromArray(seg_npy)
         seg_itk_new.CopyInformation(seg_itk)
         sitk.WriteImage(seg_itk_new, s)

--- a/lightm-unet/nnunetv2/utilities/overlay_plots.py
+++ b/lightm-unet/nnunetv2/utilities/overlay_plots.py
@@ -79,7 +79,9 @@ def generate_overlay(input_image: np.ndarray, segmentation: np.ndarray, mapping:
 
     # rescale image to [0, 255]
     image = image - image.min()
-    image = image / image.max() * 255
+    img_max = image.max()
+    scale = np.reciprocal(img_max) if img_max != 0 else 0.0
+    image = image * scale * 255
 
     # create output
     if mapping is None:
@@ -90,7 +92,9 @@ def generate_overlay(input_image: np.ndarray, segmentation: np.ndarray, mapping:
         image[segmentation == l] += overlay_intensity * np.array(hex_to_rgb(color_cycle[mapping[l]]))
 
     # rescale result to [0, 255]
-    image = image / image.max() * 255
+    img_max = image.max()
+    scale = np.reciprocal(img_max) if img_max != 0 else 0.0
+    image = image * scale * 255
     return image.astype(np.uint8)
 
 
@@ -122,7 +126,9 @@ def select_slice_to_plot2(image: np.ndarray, segmentation: np.ndarray) -> int:
     for i, c in enumerate(classes):
         fg_mask = segmentation == c
         fg_per_slice[:, i] = fg_mask.sum((1, 2))
-        fg_per_slice[:, i] /= fg_per_slice.sum()
+        den = fg_per_slice.sum()
+        inv_den = np.reciprocal(den) if den != 0 else 0.0
+        fg_per_slice[:, i] *= inv_den
     fg_per_slice = fg_per_slice.mean(1)
     return int(np.argmax(fg_per_slice))
 


### PR DESCRIPTION
## Summary
- eliminate direct division in dataset conversion scripts
- precompute reciprocal constants to reuse denominators
- avoid runtime division in overlay plotting utility

## Testing
- `pytest -q lightm-unet/nnunetv2/tests/test_mambalayer_dtype.py`

------
https://chatgpt.com/codex/tasks/task_e_68af6304a990832191f14f53b599607e